### PR TITLE
ADD FluentMultipleKeyParser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docker-compose.yml
 .mypy_cache
 .venv
 .tests
+/tests/data/test_multiple_locales/

--- a/aiogram_i18n/__main__.py
+++ b/aiogram_i18n/__main__.py
@@ -1,6 +1,5 @@
-
 from pathlib import Path
-from typing import Dict, Callable, Tuple, Sequence
+from typing import Dict, Callable, Tuple, Sequence, Union
 
 import click
 
@@ -40,21 +39,74 @@ def stub(input_files: Tuple[str, ...], output_file: str) -> None:
 
 
 @main.command(help="Extract all used fluent keys from code")  # type: ignore[misc]
-@click.option("-i", "--input-dirs", required=True, multiple=True)
-@click.option("-o", "--output-file", required=True)
-@click.option("-k", "--i18n-keys", default=["i18n", "L"], multiple=True, show_default=True)
-@click.option("-s", "--separator", default="-", show_default=True)
-@click.option("-ed", "--exclude-dirs", default=["venv"], multiple=True)
-@click.option("-ek", "--exclude-keys", multiple=True)
+@click.option(
+    "-i",
+    "--input-dirs",
+    multiple=True,
+    required=True,
+    type=click.Path(exists=True),
+)
+@click.option(
+    "-o",
+    "--output-file",
+    required=True,
+    type=click.Path(),
+)
+@click.option(
+    "-k",
+    "--i18n-keys",
+    default=["i18n", "L"],
+    multiple=True,
+    show_default=True,
+)
+@click.option(
+    "-s",
+    "--separator",
+    default="-",
+    show_default=True,
+)
+@click.option(
+    "-l",
+    "--locales",
+    multiple=True,
+)
+@click.option(
+    "-ed",
+    "--exclude-dirs",
+    default=(Path("venv"), Path(".venv")),
+    multiple=True,
+    type=click.Path(),
+)
+@click.option(
+    "-ek",
+    "--exclude-keys",
+    multiple=True,
+)
+@click.option(
+    "-cm",
+    "--create-missing-dirs",
+    is_flag=True,
+    default=False,
+)
 def extract(
-    input_dirs: Tuple[str, ...], output_file: str,
-    i18n_keys: Tuple[str, ...], separator: str,
-    exclude_dirs: Tuple[str, ...], exclude_keys: Tuple[str, ...]
+        input_dirs: Tuple[str, ...],
+        output_file: str,
+        i18n_keys: Tuple[str, ...],
+        separator: str,
+        locales: Union[Tuple[str, ...], None],
+        exclude_dirs: Tuple[str, ...],
+        exclude_keys: Tuple[str, ...],
+        create_missing_dirs: bool,
 ) -> None:
     from aiogram_i18n import I18nContext
     from aiogram_i18n.utils.fluent_extract import FluentKeyParser
 
-    exclude_dirs += "__pycache__",
+    input_dirs = tuple(Path(input_dir) for input_dir in input_dirs)
+    output_file = Path(output_file)
+
+    exclude_dirs = tuple(Path(exclude_dir) for exclude_dir in exclude_dirs)
+    exclude_dirs += (Path("__pycache__"),)
+
     exclude_keys += tuple(
         key for key, value in I18nContext.__dict__.items() if callable(value)
     )
@@ -64,11 +116,109 @@ def extract(
         output_file=output_file,
         i18n_keys=i18n_keys,
         separator=separator,
+        locales=locales,
         exclude_dirs=exclude_dirs,
-        exclude_keys=exclude_keys
+        exclude_keys=exclude_keys,
     )
-    fkp.run()
+    fkp.run(create_missing_dirs=create_missing_dirs)
 
 
-if __name__ == '__main__':
+@main.command(
+    help="Extract all used fluent keys from code and split them by files")  # type: ignore[misc]
+@click.option(
+    "-i",
+    "--input-paths",
+    multiple=True,
+    required=True,
+    type=click.Path(exists=True),
+)
+@click.option(
+    "-o",
+    "--output-dir",
+    required=True,
+    type=click.Path(),
+)
+@click.option(
+    "-k",
+    "--i18n-keys",
+    default=["i18n", "L"],
+    multiple=True,
+    show_default=True,
+)
+@click.option(
+    "-s",
+    "--separator",
+    default="-",
+    show_default=True,
+)
+@click.option(
+    "-l",
+    "--locales",
+    multiple=True,
+)
+@click.option(
+    "-ed",
+    "--exclude-dirs",
+    default=(Path("venv"), Path(".venv")),
+    multiple=True,
+    type=click.Path(),
+)
+@click.option(
+    "-ek",
+    "--exclude-keys",
+    multiple=True,
+)
+@click.option(
+    "-cm",
+    "--create-missing-dirs",
+    is_flag=True,
+    default=False,
+)
+def multiple_extract(
+        input_paths: Tuple[str, ...],
+        output_dir: str,
+        i18n_keys: Tuple[str, ...],
+        separator: str,
+        locales: Union[Tuple[str, ...], None],
+        exclude_dirs: Tuple[str, ...],
+        exclude_keys: Tuple[str, ...],
+        create_missing_dirs: bool,
+) -> None:
+    """
+    Extracts all used fluent keys from code and saves them in the specified files.
+
+    Keys should be separated by <type>-<key_name>.
+    Keys will be saved in multiple files, depending on the type.
+    The type is specified by the first part of the key.
+
+    Example:
+        - "buttons-cancel" -> "buttons" is the type, "cancel" is the key name.
+        - "checker-no-rights" -> "checker" is the type, "no-rights" is the key name.
+    """
+    from aiogram_i18n import I18nContext
+    from aiogram_i18n.utils.fluent_extract import FluentMultipleKeyParser
+
+    input_paths = tuple(Path(input_path) for input_path in input_paths)
+    output_dir = Path(output_dir)
+
+    exclude_dirs = tuple(Path(exclude_dir) for exclude_dir in exclude_dirs)
+    exclude_dirs += (Path("__pycache__"),)
+
+    exclude_keys += tuple(
+        key for key, value in I18nContext.__dict__.items() if callable(value)
+    )
+
+    fkp = FluentMultipleKeyParser(
+        input_paths=input_paths,
+        output_dir=output_dir,
+        i18n_keys=i18n_keys,
+        separator=separator,
+        locales=locales,
+        exclude_dirs=exclude_dirs,
+        exclude_keys=exclude_keys,
+    )
+    fkp.run(create_missing_dirs=create_missing_dirs)
+
+
+if __name__ == "__main__":
     main()

--- a/aiogram_i18n/utils/fluent_extract/__init__.py
+++ b/aiogram_i18n/utils/fluent_extract/__init__.py
@@ -1,13 +1,18 @@
-
 from aiogram_i18n.exceptions import NoModuleError
 
 try:
-    from .parser import FluentKeyParser
-    from .models import FluentKeywords, FluentTemplate, FluentMatch
+    from .base import BaseFluentKeyParser
+    from .parser import FluentKeyParser, FluentMultipleKeyParser
+    from .models import FluentKeywords, FluentMatch, FluentTemplate, FluentTemplateDir
 except ImportError:
     raise NoModuleError(name="Fluent key extractor", module_name="libcst")
 
-
 __all__ = [
-    "FluentKeyParser", "FluentKeywords", "FluentTemplate", "FluentMatch"
+    "BaseFluentKeyParser",
+    "FluentKeyParser",
+    "FluentKeywords",
+    "FluentMatch",
+    "FluentMultipleKeyParser",
+    "FluentTemplate",
+    "FluentTemplateDir",
 ]

--- a/aiogram_i18n/utils/fluent_extract/base.py
+++ b/aiogram_i18n/utils/fluent_extract/base.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence, Dict, cast, Any, Union
+
+from click import echo
+from libcst import matchers as m, Module, parse_module
+
+from .models import FluentKeywords, FluentMatch
+from ... import LazyProxy
+
+
+class BaseFluentKeyParser:
+    def __init__(
+            self,
+            exclude_dirs: Sequence[Path],
+            i18n_keys: Sequence[str],
+            separator: str,
+            locales: Union[Sequence[str], None],
+    ) -> None:
+        self.exclude_dirs = exclude_dirs
+        self.i18n_keys = set(i18n_keys)
+        self.separator = separator
+        self.locales = locales
+        self.result: Dict[str, FluentKeywords] = {}
+
+    @property
+    def _matcher(self) -> m.OneOf[m.Call]:
+        keywords = m.SaveMatchedNode(
+            m.ZeroOrMore(m.Arg(keyword=m.Name())), name="keywords"
+        )
+
+        return m.Call(
+            func=m.Attribute(
+                value=m.OneOf(*map(m.Name, self.i18n_keys)),
+                attr=m.Name(value="get"),
+            )
+                 | m.Name(value=LazyProxy.__name__),
+            args=[
+                m.Arg(value=m.SaveMatchedNode(m.SimpleString(), name="string")),
+                keywords,
+            ],
+        ) | m.Call(
+            func=m.Attribute(
+                value=m.OneOf(*map(m.Name, self.i18n_keys)),
+                attr=(m.SaveMatchedNode(m.Name(), name="name")),
+            )
+                 | m.SaveMatchedNode(
+                m.Attribute(
+                    value=m.Attribute(value=m.OneOf(*map(m.Name, self.i18n_keys))),
+                ),
+                name="attribute",
+            ),
+            args=[keywords],
+        )
+
+    def parse_tree(self, tree: Module) -> None:
+        keys: Dict[str, FluentKeywords] = {}
+        matches = tuple(
+            FluentMatch(**cast(Dict[str, Any], match))
+            for match in m.extractall(tree, self._matcher)
+        )
+
+        for i, match in enumerate(matches):
+            key = match.extract_key(self.separator, self.i18n_keys)
+            kw = keys.get(key, None)
+            if kw is not None:
+                kw.keywords.extend(match.extract_keywords())
+                continue
+
+            keys[key] = FluentKeywords(keywords=match.extract_keywords())
+
+        self.result.update(keys)
+
+    def parse_file(self, path: Path) -> None:
+        try:
+            with path.open(mode="r", encoding="utf-8") as py:
+                tree = parse_module(py.read())
+                self.parse_tree(tree)
+
+        except PermissionError as e:
+            echo(f"Can't parse file {path}: {e}")
+
+    def parse_dir(self, path: Path) -> None:
+        for p in path.iterdir():
+            _path = path / p
+
+            if p.name.startswith(".") or p in self.exclude_dirs:
+                continue
+
+            if _path.is_dir():
+                self.parse_dir(_path)
+
+            elif _path.suffix == ".py":
+                self.parse_file(_path)
+
+    def run(self) -> None:
+        raise NotImplementedError

--- a/aiogram_i18n/utils/fluent_extract/models.py
+++ b/aiogram_i18n/utils/fluent_extract/models.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-import os
 import re
+from copy import copy
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple, cast, Optional, Sequence, Set
+from pathlib import Path
+from typing import Dict, List, Tuple, cast, Optional, Sequence, Set, Final
 
 from click import echo
 from libcst import Arg, SimpleString, Name, Attribute, CSTNode
-from pydantic import BaseModel, Field
+
+RE_LINE: Final[re.Pattern] = re.compile(r"([^#]+) =")
 
 
 @dataclass
@@ -28,27 +30,28 @@ class FluentMatch:
         if self.string:
             return self.string.raw_value
         return re.sub(
-            f"({'|'.join(keys)}){sep}", "",
-            self.full_attr_name(cast(Attribute, self.attribute), sep=sep)
+            f"({'|'.join(keys)}){sep}",
+            "",
+            self.full_attr_name(cast(Attribute, self.attribute), sep=sep),
         )
 
     def extract_keywords(self) -> List[str]:
-        return [
-            cast(Name, arg.keyword).value for arg in self.keywords
-        ]
+        return [cast(Name, arg.keyword).value for arg in self.keywords]
 
 
-class FluentKeywords(BaseModel):
-    keywords: List[str] = Field(default_factory=list)
+@dataclass
+class FluentKeywords:
+    keywords: List[str] = field(default_factory=list)
 
     def get_placeholders(self) -> Sequence[str]:
         return [f"{{ ${p} }}" for p in set(self.keywords)]
 
 
-class FluentTemplate(BaseModel):
-    filename: str
+@dataclass
+class FluentTemplate:
+    filename: Path
     keys: Dict[str, FluentKeywords]
-    exclude_keys: List[str] = Field(default_factory=list)
+    exclude_keys: List[str] = field(default_factory=list)
 
     def need_comment(self, key: str, text: str) -> bool:
         return key not in self.keys and not re.search(rf"{{\s*{key}\s*}}", text)
@@ -57,13 +60,13 @@ class FluentTemplate(BaseModel):
         lines: List[str] = []
         removed = 0
 
-        with open(self.filename, mode="r", encoding="utf-8") as template:
+        with self.filename.open(mode="r", encoding="utf-8") as template:
             raw_lines = template.readlines()
             raw_text = "".join(raw_lines)
             comment: bool = False
 
             for line in raw_lines:
-                match = re.match(r"([^#]+) =", line)
+                match = RE_LINE.match(line)
                 if match:
                     key = match.group(1)
                     comment = self.need_comment(key, raw_text)
@@ -71,15 +74,20 @@ class FluentTemplate(BaseModel):
                         removed += 1
                     self.exclude_keys.append(key)
                 if comment:
-                    line = "# " + line
+                    line = f"# {line}"
                 lines.append(line)
 
         echo(f"Removed {removed} keys.")
         return lines
 
-    def write(self) -> None:
+    def write(self, create_missing_dirs: bool = False) -> None:
+        for key, kw in self.keys.items():
+            for keyword in copy(kw.keywords):
+                if keyword == "locale":
+                    kw.keywords.remove(keyword)
+
         lines: List[str] = []
-        if os.path.exists(self.filename):
+        if self.filename.exists():
             lines.extend(self.update())
 
         counter = 0
@@ -92,6 +100,42 @@ class FluentTemplate(BaseModel):
             lines.append(f"{key} = {value}\n")
 
         echo(f"Found {counter} new keys.")
-        with open(self.filename, mode="w", encoding="utf-8") as template:
-            echo(f"Writing '{self.filename}' template.")
+
+        if create_missing_dirs:
+            for path in reversed(self.filename.parents):
+                path.mkdir(exist_ok=True)
+
+        with self.filename.open(mode="w", encoding="utf-8") as template:
+            echo(f"Writing '{self.filename.name}' template.")
             template.write("".join(lines))
+
+
+@dataclass
+class FluentTemplateDir:
+    path: Path
+    separator: str
+    keys: Dict[str, FluentKeywords]
+    exclude_keys: List[str] = field(default_factory=list)
+
+    def write(self, create_missing_dirs: bool = False) -> None:
+        if create_missing_dirs:
+            for path in reversed(self.path.parents):
+                path.mkdir(exist_ok=True)
+
+        filenames: Set[str] = set(
+            key.split(self.separator, maxsplit=1)[0]
+            for key in self.keys.keys()
+            if key not in self.exclude_keys
+        )
+
+        for filename in filenames:
+            template = FluentTemplate(
+                self.path / f"{filename}.ftl",
+                {
+                    key: kw
+                    for key, kw in self.keys.items()
+                    if key.split(self.separator, maxsplit=1)[0] == filename
+                },
+                self.exclude_keys,
+            )
+            template.write(create_missing_dirs=create_missing_dirs)

--- a/aiogram_i18n/utils/fluent_extract/parser.py
+++ b/aiogram_i18n/utils/fluent_extract/parser.py
@@ -1,106 +1,93 @@
 from __future__ import annotations
 
 import os
-from typing import Sequence, Dict, cast, Any
+from pathlib import Path
+from typing import Sequence, Union
 
-from click import echo
-from libcst import parse_module, matchers as m, Module
-
-from .models import FluentTemplate, FluentMatch, FluentKeywords
-from ... import LazyProxy
+from .base import BaseFluentKeyParser
+from .models import FluentTemplate, FluentTemplateDir
 
 
-class FluentKeyParser:
+class FluentKeyParser(BaseFluentKeyParser):
     def __init__(
-        self,
-        input_dirs: Sequence[str], output_file: str,
-        i18n_keys: Sequence[str], separator: str,
-        exclude_dirs: Sequence[str], exclude_keys: Sequence[str]
+            self,
+            input_dirs: Sequence[Path],
+            output_file: Path,
+            i18n_keys: Sequence[str],
+            separator: str,
+            locales: Union[Sequence[str], None],
+            exclude_dirs: Sequence[Path],
+            exclude_keys: Sequence[str],
     ) -> None:
+        super().__init__(exclude_dirs, i18n_keys, separator, locales)
         self.input_dirs = set(input_dirs)
         self.output_file = output_file
-        self.i18n_keys = set(i18n_keys)
-        self.separator = separator
         self.exclude_dirs = exclude_dirs
         self.exclude_keys = list(exclude_keys)
-        self.result: Dict[str, FluentKeywords] = {}
 
-    @property
-    def _matcher(self) -> m.OneOf[m.Call]:
-        keywords = m.SaveMatchedNode(
-            m.ZeroOrMore(m.Arg(keyword=m.Name())), name="keywords"
-        )
-
-        return m.Call(
-            func=m.Attribute(
-                value=m.OneOf(*map(m.Name, self.i18n_keys)),
-                attr=m.Name(value="get"),
-            ) | m.Name(value=LazyProxy.__name__),
-            args=[
-                m.Arg(value=m.SaveMatchedNode(m.SimpleString(), name="string")),
-                keywords
-            ]
-        ) | m.Call(
-            func=m.Attribute(
-                value=m.OneOf(*map(m.Name, self.i18n_keys)),
-                attr=(m.SaveMatchedNode(m.Name(), name="name"))
-            ) | m.SaveMatchedNode(
-                m.Attribute(
-                    value=m.Attribute(value=m.OneOf(*map(m.Name, self.i18n_keys))),
-                ), name="attribute"
-            ),
-            args=[keywords]
-        )
-
-    def parse_tree(self, tree: Module) -> None:
-        keys: Dict[str, FluentKeywords] = {}
-        matches = tuple(
-            FluentMatch(**cast(Dict[str, Any], match)) for match in
-            m.extractall(tree, self._matcher)
-        )
-
-        for match in matches:
-            key = match.extract_key(self.separator, self.i18n_keys)
-            kw = keys.get(key, None)
-            if kw is not None:
-                kw.keywords.extend(match.extract_keywords())
-                continue
-            keys[key] = FluentKeywords(keywords=match.extract_keywords())
-
-        self.result.update(keys)
-
-    def parse_file(self, path: str) -> None:
-        try:
-            with open(path, mode="r", encoding="utf-8") as py:
-                tree = parse_module(py.read())
-                self.parse_tree(tree)
-
-        except PermissionError as e:
-            echo(f"Can't parse file {path}: {e}")
-
-    def parse_dir(self, path: str) -> None:
-        for p in os.listdir(path):
-            _path = os.path.join(path, p)
-
-            if p.startswith(".") or p in self.exclude_dirs:
-                continue
-
-            if os.path.isdir(_path):
-                self.parse_dir(_path)
-
-            elif _path.endswith(".py"):
-                self.parse_file(os.path.join(path, p))
-
-    def run(self) -> None:
+    def run(self, create_missing_dirs: bool = False) -> None:
         for path in self.input_dirs:
             if os.path.isdir(path):
                 self.parse_dir(path)
             else:
                 self.parse_file(path)
 
-        template = FluentTemplate(
-            filename=self.output_file,
-            keys=self.result,
-            exclude_keys=self.exclude_keys
-        )
-        template.write()
+        if self.locales:
+            for locale in self.locales:
+                template = FluentTemplate(
+                    filename=self.output_file.parent / locale / self.output_file.name,
+                    keys=self.result,
+                    exclude_keys=self.exclude_keys,
+                )
+                template.write(create_missing_dirs=create_missing_dirs)
+
+        else:
+            template = FluentTemplate(
+                filename=self.output_file,
+                keys=self.result,
+                exclude_keys=self.exclude_keys,
+            )
+            template.write(create_missing_dirs=create_missing_dirs)
+
+
+class FluentMultipleKeyParser(BaseFluentKeyParser):
+    def __init__(
+            self,
+            input_paths: Sequence[Path],
+            output_dir: Path,
+            i18n_keys: Sequence[str],
+            separator: str,
+            locales: Union[Sequence[str], None],
+            exclude_dirs: Sequence[Path],
+            exclude_keys: Sequence[str],
+    ) -> None:
+        super().__init__(exclude_dirs, i18n_keys, separator, locales)
+        self.input_paths = set(input_paths)
+        self.output_dir = output_dir
+        self.exclude_keys = list(exclude_keys)
+
+    def run(self, create_missing_dirs: bool = False) -> None:
+        for path in self.input_paths:
+            if path.is_dir():
+                self.parse_dir(path)
+            else:
+                self.parse_file(path)
+
+        if self.locales:
+            for locale in self.locales:
+                template = FluentTemplateDir(
+                    path=self.output_dir / locale,
+                    separator=self.separator,
+                    keys=self.result,
+                    exclude_keys=self.exclude_keys,
+                )
+                template.write(create_missing_dirs=create_missing_dirs)
+
+        else:
+            template = FluentTemplateDir(
+                path=self.output_dir,
+                separator=self.separator,
+                keys=self.result,
+                exclude_keys=self.exclude_keys,
+            )
+            template.write(create_missing_dirs=create_missing_dirs)

--- a/tests/test_multiple_extract.py
+++ b/tests/test_multiple_extract.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+from typing import Any, Final
+
+import pytest
+from pytest_asyncio import fixture
+from pytest_lazyfixture import lazy_fixture
+
+from aiogram_i18n.cores import BaseCore
+from aiogram_i18n.utils.fluent_extract import FluentMultipleKeyParser
+
+TEST_LOCALES_DIR: Final[str] = "test_multiple_locales"
+LOCALES: Final[str] = str(
+    Path(__file__).parent.joinpath("data", TEST_LOCALES_DIR, "{locale}").absolute()
+)
+
+
+@fixture(scope="class")
+def fluent_runtime_core_multiple() -> BaseCore[Any]:
+    from aiogram_i18n.cores import FluentRuntimeCore
+
+    return FluentRuntimeCore(path=LOCALES, use_isolating=False)
+
+
+@fixture(scope="class")
+def fluent_compile_core_multiple() -> BaseCore[Any]:
+    from aiogram_i18n.cores import FluentCompileCore
+
+    return FluentCompileCore(path=LOCALES, use_isolating=False)
+
+
+@pytest.mark.parametrize(
+    "i18n",
+    [
+        lazy_fixture("fluent_runtime_core_multiple"),
+        lazy_fixture("fluent_compile_core_multiple"),
+    ],
+)
+@pytest.mark.asyncio
+class Test:
+    async def test_multiple_extract(self, i18n: BaseCore[Any]) -> None:
+        input_paths = (Path(__file__).absolute(),)
+        output_dir = (
+            Path(__file__).parent.joinpath("data", TEST_LOCALES_DIR).absolute()
+        )
+
+        fkp = FluentMultipleKeyParser(
+            input_paths=input_paths,
+            output_dir=output_dir,
+            i18n_keys=["i18n", "L"],
+            separator="-",
+            locales=["en", "uk"],
+            exclude_dirs=[],
+            exclude_keys=["startup", "shutdown"],
+        )
+        fkp.run(create_missing_dirs=True)
+
+        assert i18n.available_locales == ()
+        await i18n.startup()
+        assert set(i18n.available_locales) == {"en", "uk"}
+
+    async def test_get(self, i18n: BaseCore[Any]) -> None:
+        assert i18n.get("start", locale="en") == "start"
+        assert i18n.get("start", locale="uk") == "start"
+
+        assert i18n.get("buttons-cancel", locale="en") == "buttons-cancel"
+        assert i18n.get("buttons-cancel", locale="uk") == "buttons-cancel"
+
+        assert (
+                i18n.get("buttons-add-user", locale="en", user="Bob")
+                == "buttons-add-user Bob"
+        )
+        assert (
+                i18n.get("buttons-add-user", locale="uk", user="Боб")
+                == "buttons-add-user Боб"
+        )
+
+        assert i18n.get("msgs-hello", locale="en", user="Bob") == "msgs-hello Bob"
+        assert i18n.get("msgs-hello", locale="uk", user="Боб") == "msgs-hello Боб"
+
+        assert i18n.get("msgs-bye", locale="en", user="Bob") == "msgs-bye Bob"
+        assert i18n.get("msgs-bye", locale="uk", user="Боб") == "msgs-bye Боб"


### PR DESCRIPTION
ADD BaseFluentKeyParser
Refactor FluentKeyParser to use Path instead of str Fix `locale=` in i18n.get(...) not to be gathered by parser

Now Parsers accepts `locales`, which will create sub-dirs (eg. `uk`, `en`). If locales is None - no sub-dirs will be created.

FluentMultipleKeyParser parses locale-tokens in code and split them by separator. [`token.split(maxsplit=1)`] First element of local-token is used to create sub-ftl-files for them. Also u can pass locales and create sub-dirs with sub-ftl-files.

The code was formatted by Black + Ruff.