### PR TITLE
refactor translation key generation in Jinja2Core

### DIFF
--- a/aiogram_i18n/cores/jinja2_core.py
+++ b/aiogram_i18n/cores/jinja2_core.py
@@ -22,7 +22,7 @@ class Jinja2Core(BaseCore[Dict]):
         raise_key_error: bool = True,
         use_td: bool = True,
         locales_map: Optional[Dict[str, str]] = None,
-        key_seperator: str = "-",
+        key_separator: str = "-",
     ) -> None:
         super().__init__(path=path, default_locale=default_locale, locales_map=locales_map)
         self.environment = environment or Environment(autoescape=True)
@@ -55,6 +55,6 @@ class Jinja2Core(BaseCore[Dict]):
                     content = self.environment.from_string(f.read())
                     relative_file_path = file_path.relative_to(self.path / locale)
                     parts = relative_file_path.with_suffix("").parts
-                    key = self.key_seperator.join(parts)
+                    key = self.key_separator.join(parts)
                     translations[locale][key] = content
         return translations

--- a/aiogram_i18n/cores/jinja2_core.py
+++ b/aiogram_i18n/cores/jinja2_core.py
@@ -22,6 +22,7 @@ class Jinja2Core(BaseCore[Dict]):
         raise_key_error: bool = True,
         use_td: bool = True,
         locales_map: Optional[Dict[str, str]] = None,
+        key_seperator: str = "-",
     ) -> None:
         super().__init__(path=path, default_locale=default_locale, locales_map=locales_map)
         self.environment = environment or Environment(autoescape=True)
@@ -29,6 +30,7 @@ class Jinja2Core(BaseCore[Dict]):
             for name, func in td.functions.items():
                 self.environment.filters[name.lower()] = func
         self.raise_key_error = raise_key_error
+        self.key_seperator = key_seperator
 
     def get(self, message_id: str, locale: Optional[str] = None, /, **kwargs: Any) -> str:
         locale = self.get_locale(locale=locale)
@@ -51,8 +53,8 @@ class Jinja2Core(BaseCore[Dict]):
             for file_path in paths:
                 with file_path.open(encoding="utf-8") as f:
                     content = self.environment.from_string(f.read())
-                    relative_parts = (
-                        file_path.relative_to(self.path / locale).with_suffix("").parts
-                    )
-                    translations[locale]["-".join(relative_parts)] = content
+                    relative_file_path = file_path.relative_to(self.path / locale)
+                    parts = relative_file_path.with_suffix("").parts
+                    key = self.key_seperator.join(parts)
+                    translations[locale][key] = content
         return translations

--- a/aiogram_i18n/cores/jinja2_core.py
+++ b/aiogram_i18n/cores/jinja2_core.py
@@ -22,7 +22,7 @@ class Jinja2Core(BaseCore[Dict]):
         raise_key_error: bool = True,
         use_td: bool = True,
         locales_map: Optional[Dict[str, str]] = None,
-        key_seperator: str = "-",
+        key_separator: str = "-",
     ) -> None:
         super().__init__(path=path, default_locale=default_locale, locales_map=locales_map)
         self.environment = environment or Environment(autoescape=True)
@@ -30,7 +30,7 @@ class Jinja2Core(BaseCore[Dict]):
             for name, func in td.functions.items():
                 self.environment.filters[name.lower()] = func
         self.raise_key_error = raise_key_error
-        self.key_seperator = key_seperator
+        self.key_separator = key_separator
 
     def get(self, message_id: str, locale: Optional[str] = None, /, **kwargs: Any) -> str:
         locale = self.get_locale(locale=locale)
@@ -55,6 +55,6 @@ class Jinja2Core(BaseCore[Dict]):
                     content = self.environment.from_string(f.read())
                     relative_file_path = file_path.relative_to(self.path / locale)
                     parts = relative_file_path.with_suffix("").parts
-                    key = self.key_seperator.join(parts)
+                    key = self.key_separator.join(parts)
                     translations[locale][key] = content
         return translations

--- a/aiogram_i18n/cores/jinja2_core.py
+++ b/aiogram_i18n/cores/jinja2_core.py
@@ -50,6 +50,9 @@ class Jinja2Core(BaseCore[Dict]):
             translations[locale] = {}
             for file_path in paths:
                 with file_path.open(encoding="utf-8") as f:
-                    translations[locale][file_path.stem] = self.environment.from_string(f.read())
-
+                    content = self.environment.from_string(f.read())
+                    relative_parts = (
+                        file_path.relative_to(self.path / locale).with_suffix("").parts
+                    )
+                    translations[locale]["-".join(relative_parts)] = content
         return translations


### PR DESCRIPTION
Keys are now generated based on the relative file path, not just the stem file.
This allows you to support a nested template structure, e.g:

```
locales/en/
  main/
    hello.j2
    buttons/
      settings.j2
      profile.j2
```
They can be accessed like this:

```python
i18n.main.hello()
i18n.main.buttons.settings()
````