### PR TITLE
 Improve user-friendly error output for Fluent

### DIFF
--- a/examples/language_inline_markup.py
+++ b/examples/language_inline_markup.py
@@ -28,14 +28,14 @@ async def cmd_start(message: Message, i18n: I18nContext):
 
 
 @router.callback_query(F.data == "back")
-async def btn_help(call: CallbackQuery, i18n: I18nContext):
+async def btn_back(call: CallbackQuery, i18n: I18nContext):
     await call.message.edit_text(
         text=i18n.get("hello", user=call.from_user.full_name)
     )
 
 
 @router.callback_query(lang_kb.filter)
-async def btn_help(call: CallbackQuery, lang: str, i18n: I18nContext):
+async def btn_lang(call: CallbackQuery, lang: str, i18n: I18nContext):
     await call.answer()
     await i18n.set_locale(locale=lang)
     await call.message.edit_text(text=i18n.cur.lang(language=i18n.locale))

--- a/src/aiogram_i18n/cores/fluent_compile_core.py
+++ b/src/aiogram_i18n/cores/fluent_compile_core.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
-from aiogram_i18n.exceptions import KeyNotFoundError, NoModuleError
+from aiogram_i18n.exceptions import KeyNotFoundError, NoModuleError, FluentMessageError
 from aiogram_i18n.utils.text_decorator import td
 
 try:
@@ -44,7 +44,7 @@ class FluentCompileCore(BaseCore[FluentBundle]):
                 raise KeyNotFoundError(message) from None
             return message
         if errors:
-            raise errors[0]
+            raise FluentMessageError(message_id=message, errors=errors)
         return cast(str, text)  # 'cause fluent_compiler type-ignored
 
     def find_locales(self) -> dict[str, FluentBundle]:

--- a/src/aiogram_i18n/cores/fluent_compile_core.py
+++ b/src/aiogram_i18n/cores/fluent_compile_core.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
-from aiogram_i18n.exceptions import KeyNotFoundError, NoModuleError, FluentMessageError
+from aiogram_i18n.exceptions import FluentMessageError, KeyNotFoundError, NoModuleError
 from aiogram_i18n.utils.text_decorator import td
 
 try:

--- a/src/aiogram_i18n/cores/fluent_runtime_core.py
+++ b/src/aiogram_i18n/cores/fluent_runtime_core.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
-from aiogram_i18n.exceptions import KeyNotFoundError, NoModuleError
+from aiogram_i18n.exceptions import KeyNotFoundError, NoModuleError, FluentMessageError
 from aiogram_i18n.utils.text_decorator import td
 
 try:
@@ -49,7 +49,7 @@ class FluentRuntimeCore(BaseCore[FluentBundle]):
             return message_id
         text, errors = translator.format_pattern(pattern=message.value, args=kwargs)
         if errors:
-            raise errors[0]
+            raise FluentMessageError(message_id=message_id, errors=errors)
         return cast(str, text)
 
     def find_locales(self) -> dict[str, FluentBundle]:

--- a/src/aiogram_i18n/cores/fluent_runtime_core.py
+++ b/src/aiogram_i18n/cores/fluent_runtime_core.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
-from aiogram_i18n.exceptions import KeyNotFoundError, NoModuleError, FluentMessageError
+from aiogram_i18n.exceptions import FluentMessageError, KeyNotFoundError, NoModuleError
 from aiogram_i18n.utils.text_decorator import td
 
 try:

--- a/src/aiogram_i18n/exceptions.py
+++ b/src/aiogram_i18n/exceptions.py
@@ -86,6 +86,7 @@ class FluentMessageError(AiogramI18nError):
         self.errors = errors
 
     def __str__(self) -> str:
-        lines = [f"\n{len(self.errors)} errors for key '{self.message_id}':"]
+        error_word = "error" if len(self.errors) == 1 else "errors"
+        lines = [f"\n{len(self.errors)} {error_word} for key '{self.message_id}':"]
         lines.extend(f"  {err} (type={type(err).__name__})" for err in self.errors)
         return "\n".join(lines)

--- a/src/aiogram_i18n/exceptions.py
+++ b/src/aiogram_i18n/exceptions.py
@@ -78,3 +78,15 @@ class UnknownLocaleError(AiogramI18nError):
 
     def __str__(self) -> str:
         return self.message.format(locale=self.locale)
+
+
+class FluentMessageError(AiogramI18nError):
+    def __init__(self, message_id: str, errors: List[Exception]) -> None:
+        self.message_id = message_id
+        self.errors = errors
+
+    def __str__(self) -> str:
+        lines = [f"\n{len(self.errors)} errors for message '{self.message_id}':"]
+        for idx, err in enumerate(self.errors, start=1):
+            lines.append(f"  {err} (type={err.__class__.__name__})")
+        return "\n".join(lines)

--- a/src/aiogram_i18n/exceptions.py
+++ b/src/aiogram_i18n/exceptions.py
@@ -86,7 +86,7 @@ class FluentMessageError(AiogramI18nError):
         self.errors = errors
 
     def __str__(self) -> str:
-        lines = [f"\n{len(self.errors)} errors for message '{self.message_id}':"]
+        lines = [f"\n{len(self.errors)} errors for key '{self.message_id}':"]
         for idx, err in enumerate(self.errors, start=1):
             lines.append(f"  {err} (type={err.__class__.__name__})")
         return "\n".join(lines)

--- a/src/aiogram_i18n/exceptions.py
+++ b/src/aiogram_i18n/exceptions.py
@@ -81,12 +81,11 @@ class UnknownLocaleError(AiogramI18nError):
 
 
 class FluentMessageError(AiogramI18nError):
-    def __init__(self, message_id: str, errors: List[Exception]) -> None:
+    def __init__(self, message_id: str, errors: list[Exception]) -> None:
         self.message_id = message_id
         self.errors = errors
 
     def __str__(self) -> str:
         lines = [f"\n{len(self.errors)} errors for key '{self.message_id}':"]
-        for err in self.errors:
-            lines.append(f"  {err} (type={err.__class__.__name__})")
+        lines.extend(f"  {err} (type={type(err).__name__})" for err in self.errors)
         return "\n".join(lines)

--- a/src/aiogram_i18n/exceptions.py
+++ b/src/aiogram_i18n/exceptions.py
@@ -87,6 +87,6 @@ class FluentMessageError(AiogramI18nError):
 
     def __str__(self) -> str:
         lines = [f"\n{len(self.errors)} errors for key '{self.message_id}':"]
-        for idx, err in enumerate(self.errors, start=1):
+        for err in self.errors:
             lines.append(f"  {err} (type={err.__class__.__name__})")
         return "\n".join(lines)


### PR DESCRIPTION
FTL file:
```fluent
hello = Hello, <b>{ $firstname } { $lastname }</b>!
```

<br>

Before:
```python
fluent.runtime.errors.FluentReferenceError: Unknown external: firstname
```

After:
```python
aiogram_i18n.exceptions.FluentMessageError: 
2 errors for key 'hello':
  Unknown external: firstname (type=FluentReferenceError)
  Unsupported external type: lastname, <class 'NoneType'> (type=TypeError)
```